### PR TITLE
improving the ux of the claim button

### DIFF
--- a/src/components/DetailsReports.tsx
+++ b/src/components/DetailsReports.tsx
@@ -119,9 +119,9 @@ const DetailsReports = () => {
 
   const reclamarButtonText = (() => {
     if (lostObject.type === "encontrado") {
-      return "devolver";
+      return "reclamar";
     } else {
-      return lostObject.type === "perdido" ? "Reclamar" : "devolver";
+      return lostObject.type === "perdido" ? "devolver" : "reclamar";
     }
   })();
 

--- a/src/components/DetailsReports.tsx
+++ b/src/components/DetailsReports.tsx
@@ -117,6 +117,14 @@ const DetailsReports = () => {
     }
   };
 
+  const reclamarButtonText = (() => {
+    if (lostObject.type === "encontrado") {
+      return "devolver";
+    } else {
+      return lostObject.type === "perdido" ? "Reclamar" : "devolver";
+    }
+  })();
+
   const [state, setState] = useState({
     left: false,
     right: false,
@@ -422,14 +430,13 @@ const DetailsReports = () => {
               color="success"
               fullWidth
               disabled={
-                isCurrentUserOwner === true ||
+                isCurrentUserOwner ||
                 lostObject.status === "finalizado" ||
-                lostObject.status === "reclamado" ||
                 lostObject.status === "enviado"
               }
               onClick={handleOpenDialog}
             >
-              Reclamar
+              {reclamarButtonText}
             </Button>
           </CardActions>
 


### PR DESCRIPTION
Se ha mejorado el nombre del botón de reclamar dependiendo de los dos distintos escenarios cuando reporta un objeto como encontrado el botón muestra "devolver" y cuando reporta que perdió un objeto muestra "reclamar".