### PR TITLE
Improving the ux of input fields

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -370,6 +370,7 @@ const LandingPage = () => {
                   label="city"
                   onChange={handleCityChange}
                   input={<OutlinedInput label="Ciudad" />}
+                  disabled={!selectedCountry}
                 >
                   {cityData.map((city: any, index: number) => (
                     <MenuItem key={index} value={city}>
@@ -377,6 +378,7 @@ const LandingPage = () => {
                     </MenuItem>
                   ))}
                 </Select>
+
                 <FormHelperText sx={errorStyles}> {cityError}</FormHelperText>
               </FormControl>
             </Grid>
@@ -392,6 +394,7 @@ const LandingPage = () => {
                   value={selectedAirport}
                   onChange={handleAirportChange}
                   input={<OutlinedInput label="Aeropuerto" />}
+                  disabled={!selectedCity}
                 >
                   {airportData.map((airport: any, index: number) => (
                     <MenuItem key={index} value={airport}>


### PR DESCRIPTION
Se mejoró la experiencia de usuario (UX) deshabilitando los Select de los inputs de ciudad si país no estaba seleccionado y aeropuerto si cuidad no se seleccionó antes para evitar llamados a la API innecesarios.